### PR TITLE
feat: temporarily remove legal pages from public access

### DIFF
--- a/src/app/[lang]/imprint/page.tsx
+++ b/src/app/[lang]/imprint/page.tsx
@@ -1,30 +1,31 @@
 import { notFound } from "next/navigation"
-import { MDXRemote } from "next-mdx-remote"
-import { mdxComponents } from "@/lib/components/content/components"
-import { getMDXContent } from "@/lib/components/content/mdx"
+// import { MDXRemote } from "next-mdx-remote"
+// import { mdxComponents } from "@/lib/components/content/components"
+// import { getMDXContent } from "@/lib/components/content/mdx"
 import type { Locale } from "@/lib/hooks/use-i18n-config"
 
 export default async function ImprintPage({ params }: { params: Promise<{ lang: Locale }> }) {
   const _params = await params
-  const content = await getMDXContent("imprint")
-
-  if (!content) {
-    notFound()
-  }
-
-  return (
-    <div className="container max-w-4xl mx-auto py-8 px-4">
-      <MDXRemote {...content.source} components={mdxComponents} />
-    </div>
-  )
+  // Temporarily block access to imprint page
+  notFound()
+  
+  // const content = await getMDXContent("imprint")
+  // if (!content) {
+  //   notFound()
+  // }
+  // return (
+  //   <div className="container max-w-4xl mx-auto py-8 px-4">
+  //     <MDXRemote {...content.source} components={mdxComponents} />
+  //   </div>
+  // )
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ lang: Locale }> }) {
   const _params = await params
-  const content = await getMDXContent("imprint")
+  // const content = await getMDXContent("imprint")
 
   return {
-    title: content?.frontmatter?.title || "Imprint",
-    description: content?.frontmatter?.description || "Legal imprint information",
+    title: "Page Not Found",
+    description: "This page is currently unavailable",
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -33,13 +33,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     })
     
-    // Imprint page
-    routes.push({
-      url: `${baseUrl}/${lang}/imprint`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 0.3,
-    })
+    // Imprint page - temporarily removed
+    // routes.push({
+    //   url: `${baseUrl}/${lang}/imprint`,
+    //   lastModified: new Date(),
+    //   changeFrequency: "yearly",
+    //   priority: 0.3,
+    // })
   })
   
   return routes

--- a/src/content/legal/imprint.mdx
+++ b/src/content/legal/imprint.mdx
@@ -1,3 +1,4 @@
+{/*
 ### Website Operator (§5 TMG)
 
 <Card>
@@ -29,3 +30,8 @@
   **Link liability:** Per §§8-10 TMG, not liable for external links  
   **Copyright:** All content protected, reproduction requires permission
 </Card>
+*/}
+
+# Imprint - Temporarily Unavailable
+
+This page is currently unavailable.

--- a/src/content/legal/privacy-policy.mdx
+++ b/src/content/legal/privacy-policy.mdx
@@ -1,3 +1,4 @@
+{/*
 ### Data Controller (GDPR Art. 13)
 
 <Card>
@@ -50,3 +51,8 @@
   **Data protection officer:** Not required (small business)  
   **Supervisory authority:** Baden-Württemberg data protection authority
 </Card>
+*/}
+
+# Privacy Policy - Temporarily Unavailable
+
+This page is currently unavailable.

--- a/src/lib/components/content/mdx.ts
+++ b/src/lib/components/content/mdx.ts
@@ -36,6 +36,11 @@ const extractFrontmatter = (content: string) => {
 export const getMDXContent = cache(async (filename: string): Promise<MDXContent | null> => {
   if (!isValidFile(filename)) return null
 
+  // Temporarily block access to legal content
+  if (filename === "imprint" || filename === "privacy-policy") {
+    return null
+  }
+
   try {
     const filePath = path.join(CONTENT_DIR, `${filename}.mdx`)
     const rawContent = await fs.readFile(filePath, "utf-8")

--- a/src/lib/components/portfolio-page-client.tsx
+++ b/src/lib/components/portfolio-page-client.tsx
@@ -47,13 +47,13 @@ function PortfolioPageClientInner({
 }) {
   const [isMeetingOpen, setIsMeetingOpen] = useState(false)
   const [isShared, setIsShared] = useState(false)
-  const [legalDrawerContent, setLegalDrawerContent] = useState<"imprint" | "privacy" | null>(null)
+  // const [legalDrawerContent, setLegalDrawerContent] = useState<"imprint" | "privacy" | null>(null)
   const { setTheme } = useTheme()
   const prefetchContent = useSetAtom(prefetchMDXContentAtom)
 
-  useEffect(() => {
-    prefetchContent(["imprint", "privacy-policy"])
-  }, [prefetchContent])
+  // useEffect(() => {
+  //   prefetchContent(["imprint", "privacy-policy"])
+  // }, [prefetchContent])
 
   const downloadAllImages = async () => {
     try {
@@ -319,6 +319,7 @@ function PortfolioPageClientInner({
           </Tooltip>
         </div>
 
+        {/* Legal links temporarily removed
         <div className="w-full max-w-[280px] space-y-2 text-center">
           <div className="flex justify-center space-x-4 text-xs">
             <Button
@@ -350,6 +351,7 @@ function PortfolioPageClientInner({
             </div>
           </DrawerContent>
         </Drawer>
+        */}
       </div>
     </TooltipProvider>
   )


### PR DESCRIPTION
- Block access to imprint and privacy policy pages via 404 redirect
- Comment out legal content in MDX files while preserving structure
- Remove legal page links from portfolio footer navigation
- Exclude imprint page from sitemap to prevent search indexing
- Add content loader blocks to prevent MDX rendering of legal files

This ensures legal information is not accessible via any public route while maintaining the ability to easily restore it later.