### PR TITLE
fix(build): eliminate module type warning in production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "portfolio",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "next build",
     "dev": "next dev",


### PR DESCRIPTION
Set package.json type to module to resolve Node.js ES module parsing warning for TypeScript config files